### PR TITLE
Circleci editor/circleci caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,22 +7,37 @@ jobs:
       - image: cimg/base:2021.04
 
     steps:
+    # Initial Git checkout with submodules
       - checkout
       - run:
           name: Install git submodules
           command: 'git submodule update --init --recursive'
+    # Restore Cache for 3rd party libs
+      - run:
+          name: Spdlog checksum
+          command: >-
+            SPDLOG_HASH=$(git ls-tree HEAD third_party/spdlog | awk {'print $3'})
+      - restore_cache:
+          key: spdlogcache-v1-{{ .Environment.SPDLOG_HASH }}
+    # Install rquired tools
       - run:
           name: Install GCC
           command: 'sudo apt-get update && sudo apt-get install -y gcc g++'
       - run:
           name: Install CMAKE
           command: 'sudo apt-get update && sudo apt-get install -y cmake'
+    # Build
       - run:
           name: Configure with CMAKE
           command: 'cmake -H. -Bbuild'
       - run:
           name: Build
           command: 'cd build && make -j8'
+    # Save Cache
+      - save_cache:
+          key: spdlogcache-v1-{{ .Environment.SPDLOG_HASH }}
+          paths: bin/spdlog
+    # Test
       - run:
           name: Test
           command: 'cd build && ctest'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           name: Spdlog checksum
           command: >-
             SPDLOG_HASH=$(git ls-tree HEAD third_party/spdlog | awk {'print $3'})
+            echo $SPDLOG_HASH
       - restore_cache:
           key: spdlogcache-v1-{{ .Environment.SPDLOG_HASH }}
     # Install rquired tools
@@ -36,7 +37,8 @@ jobs:
     # Save Cache
       - save_cache:
           key: spdlogcache-v1-{{ .Environment.SPDLOG_HASH }}
-          paths: bin/spdlog
+          paths: 
+            - bin/spdlog
     # Test
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
       - run:
           name: Spdlog checksum
           command: >-
-            SPDLOG_HASH=$(git ls-tree HEAD third_party/spdlog | awk {'print $3'}) && echo $SPDLOG_HASH
+            echo $(git ls-tree HEAD third_party/spdlog | awk {'print $3'}) >.spdlog_hash
       - restore_cache:
-          key: spdlogcache-v1-{{ .Environment.$SPDLOG_HASH }}
+          key: spdlogcache-v1-{{ checksum .spdlog_hash }}
     # Install rquired tools
       - run:
           name: Install GCC
@@ -35,7 +35,7 @@ jobs:
           command: 'cd build && make -j8'
     # Save Cache
       - save_cache:
-          key: spdlogcache-v1-{{ .Environment.$SPDLOG_HASH }}
+          key: spdlogcache-v1-{{ checksum .spdlog_hash }}
           paths: 
             - bin/spdlog
     # Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: >-
             echo $(git ls-tree HEAD third_party/spdlog | awk {'print $3'}) >.spdlog_hash
       - restore_cache:
-          key: spdlogcache-v1-{{ checksum .spdlog_hash }}
+          key: spdlogcache-v1-{{ checksum ".spdlog_hash" }}
     # Install rquired tools
       - run:
           name: Install GCC
@@ -35,7 +35,7 @@ jobs:
           command: 'cd build && make -j8'
     # Save Cache
       - save_cache:
-          key: spdlogcache-v1-{{ checksum .spdlog_hash }}
+          key: spdlogcache-v1-{{ checksum ".spdlog_hash" }}
           paths: 
             - bin/spdlog
     # Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,9 @@ jobs:
       - run:
           name: Spdlog checksum
           command: >-
-            SPDLOG_HASH=$(git ls-tree HEAD third_party/spdlog | awk {'print $3'})
-            echo $SPDLOG_HASH
+            SPDLOG_HASH=$(git ls-tree HEAD third_party/spdlog | awk {'print $3'}) && echo $SPDLOG_HASH
       - restore_cache:
-          key: spdlogcache-v1-{{ .Environment.SPDLOG_HASH }}
+          key: spdlogcache-v1-{{ .Environment.$SPDLOG_HASH }}
     # Install rquired tools
       - run:
           name: Install GCC
@@ -36,7 +35,7 @@ jobs:
           command: 'cd build && make -j8'
     # Save Cache
       - save_cache:
-          key: spdlogcache-v1-{{ .Environment.SPDLOG_HASH }}
+          key: spdlogcache-v1-{{ .Environment.$SPDLOG_HASH }}
           paths: 
             - bin/spdlog
     # Test


### PR DESCRIPTION
Add caching for spdlog for circle ci to improve build/test times. At some point I should look into doing the same with Catch2, but will need to link it as a static library first.