### PR TITLE
Fix circleCI caching.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
+# TODO: Add architecture specific nightly tests
+
 jobs:
   build:
     docker:
@@ -12,33 +14,49 @@ jobs:
       - run:
           name: Install git submodules
           command: 'git submodule update --init --recursive'
+
     # Restore Cache for 3rd party libs
+      # spdlog
       - run:
           name: Spdlog checksum
           command: >-
             echo $(git ls-tree HEAD third_party/spdlog | awk {'print $3'}) >.spdlog_hash
       - restore_cache:
           key: spdlogcache-v1-{{ checksum ".spdlog_hash" }}
-    # Install rquired tools
+      # Catch2
       - run:
-          name: Install GCC
-          command: 'sudo apt-get update && sudo apt-get install -y gcc g++'
+          name: Catch2 checksum
+          command: >-
+            echo $(git ls-tree HEAD third_party/Catch2 | awk {'print $3'}) >.catch2_hash
+      - restore_cache:
+          key: catch2cache-v1-{{ checksum ".catch2_hash" }} 
+        
+    # Install required tools
       - run:
           name: Install CMAKE
           command: 'sudo apt-get update && sudo apt-get install -y cmake'
+
     # Build
       - run:
           name: Configure with CMAKE
           command: 'cmake -H. -Bbuild'
       - run:
           name: Build
-          command: 'cd build && make -j8'
+          command: 'cd build && make -j$(nproc)'
+
     # Save Cache
+      # spdlog
       - save_cache:
           key: spdlogcache-v1-{{ checksum ".spdlog_hash" }}
           paths: 
             - bin/spdlog
+      # Catch2
+      - save_cache:
+          key: catch2cache-v1-{{ checksum ".catch2_hash" }}
+          paths:
+            - build/third_party/Catch2
+
     # Test
       - run:
           name: Test
-          command: 'cd build && ctest'
+          command: 'cd build && tests/engineTest'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,14 @@ jobs:
           command: >-
             echo $(git ls-tree HEAD third_party/spdlog | awk {'print $3'}) >.spdlog_hash
       - restore_cache:
-          key: spdlogcache-v1-{{ checksum ".spdlog_hash" }}
+          key: spdlogcache-v2-{{ checksum ".spdlog_hash" }}
       # Catch2
       - run:
           name: Catch2 checksum
           command: >-
             echo $(git ls-tree HEAD third_party/Catch2 | awk {'print $3'}) >.catch2_hash
       - restore_cache:
-          key: catch2cache-v2-{{ checksum ".catch2_hash" }} 
+          key: catch2cache-v3-{{ checksum ".catch2_hash" }} 
         
     # Install required tools
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,16 @@ jobs:
     # Save Cache
       # spdlog
       - save_cache:
-          key: spdlogcache-v1-{{ checksum ".spdlog_hash" }}
+          key: spdlogcache-v2-{{ checksum ".spdlog_hash" }}
           paths: 
             - bin/spdlog
+            - build/spdlog
       # Catch2
       - save_cache:
-          key: catch2cache-v2-{{ checksum ".catch2_hash" }}
+          key: catch2cache-v3-{{ checksum ".catch2_hash" }}
           paths:
             - bin/Catch2
+            - build/Catch2
 
     # Test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: >-
             echo $(git ls-tree HEAD third_party/Catch2 | awk {'print $3'}) >.catch2_hash
       - restore_cache:
-          key: catch2cache-v1-{{ checksum ".catch2_hash" }} 
+          key: catch2cache-v2-{{ checksum ".catch2_hash" }} 
         
     # Install required tools
       - run:
@@ -52,9 +52,9 @@ jobs:
             - bin/spdlog
       # Catch2
       - save_cache:
-          key: catch2cache-v1-{{ checksum ".catch2_hash" }}
+          key: catch2cache-v2-{{ checksum ".catch2_hash" }}
           paths:
-            - build/third_party/Catch2
+            - bin/Catch2
 
     # Test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,4 +59,4 @@ jobs:
     # Test
       - run:
           name: Test
-          command: 'cd build && tests/engineTest'
+          command: 'cd build && tests/engineTests'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,6 @@ ExternalProject_Add(
     -DSPDLOG_BUILD_SHARED=OFF
     -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR}/bin/spdlog
 )
-link_directories(${PROJECT_SOURCE_DIR}/bin/spdlog/lib)
-include_directories(${PROJECT_SOURCE_DIR}/bin/spdlog/include)
 
 # Build
 add_subdirectory(src)
@@ -52,8 +50,6 @@ if(BUILD_TESTING AND NOT_SUBPROJECT)
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
         -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR}/bin/Catch2
     )
-    link_directories(${PROJECT_SOURCE_DIR}/bin/Catch2/lib)
-    include_directories(${PROJECT_SOURCE_DIR}/bin/Catch2/include)
     list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/third_party/Catch2/extras)
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,11 +27,11 @@ ExternalProject_Add(
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-    -DCMAKE_INSTALL_PREFIX=${STAGING_DIR}
     -DSPDLOG_BUILD_SHARED=OFF
     -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR}/bin/spdlog
 )
 link_directories(${PROJECT_SOURCE_DIR}/bin/spdlog/lib)
+include_directories(${PROJECT_SOURCE_DIR}/bin/spdlog/include)
 
 # Build
 add_subdirectory(src)
@@ -41,8 +41,19 @@ target_link_libraries(shepichess PRIVATE engine)
 
 # Test
 if(BUILD_TESTING AND NOT_SUBPROJECT)
-    # catch2
-    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/Catch2)
+    ExternalProject_Add(
+        Catch2
+        PREFIX Catch2
+        SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/Catch2
+        CMAKE_ARGS 
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR}/bin/Catch2
+    )
+    link_directories(${PROJECT_SOURCE_DIR}/bin/Catch2/lib)
+    include_directories(${PROJECT_SOURCE_DIR}/bin/Catch2/include)
     list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/third_party/Catch2/extras)
     add_subdirectory(tests)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,8 +15,7 @@ target_compile_features(engine PRIVATE cxx_std_17)
 # spdlog
 add_dependencies(engine spdlog)
 target_include_directories(engine PUBLIC ${PROJECT_SOURCE_DIR}/bin/spdlog/include)
-target_link_directories(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/spdlog/lib)
-target_link_libraries(engine PRIVATE libspdlog.a)
+target_link_libraries(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/spdlog/lib/libspdlog.a)
 
 # source group
 source_group(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ target_compile_features(engine PRIVATE cxx_std_17)
 add_dependencies(engine spdlog)
 target_include_directories(engine PUBLIC ${PROJECT_SOURCE_DIR}/bin/spdlog/include)
 target_link_directories(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/spdlog/lib)
+target_link_libraries(engine PRIVATE libspdlog.a)
 
 # source group
 source_group(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,9 +13,8 @@ target_link_libraries(engineTests PRIVATE engine)
 
 add_dependencies(engineTests Catch2)
 target_include_directories(engine PUBLIC ${PROJECT_SOURCE_DIR}/bin/Catch2/include)
-target_link_directories(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib)
-target_link_libraries(engine PRIVATE libCatch2Main.a)
-target_link_libraries(engine PRIVATE libCatch2.a)
+target_link_libraries(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib/libCatch2Main.a)
+target_link_libraries(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib/libCatch2.a)
 
 include(Catch)
 catch_discover_tests(engineTests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,21 @@
 add_executable(engineTests)
 
 set(SourceFiles testbitboard.cpp)
-add_dependencies(engineTests engine)
-target_link_libraries(engineTests PRIVATE engine Catch2::Catch2WithMain)
-add_dependencies(engineTests Catch2)
+
 target_sources(
     engineTests
     PRIVATE
         ${SourceFiles}
 )
+
+add_dependencies(engineTests engine)
+target_link_libraries(engineTests PRIVATE engine)
+
+add_dependencies(engineTests Catch2)
+target_include_directories(engine PUBLIC ${PROJECT_SOURCE_DIR}/bin/Catch2/include)
+target_link_directories(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib)
+target_link_libraries(engine PRIVATE libCatch2Main.a)
+target_link_libraries(engine PRIVATE libCatch2.a)
+
 include(Catch)
 catch_discover_tests(engineTests)


### PR DESCRIPTION
Added caching for Catch2 (and changed to building a separate static library as opposed to using add_subdirectory), and updated caching in CircleCI.

Also cleaned up CMake files and fixed some linking errors.