### PR TITLE
Initial implementation of basic bitboard functionality.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# TODO: Add architecture specific nightly tests
+# TODO: Add nightly builds to test windows/clang for arch specific functions
+# TODO: Add store_test_results step
 
 jobs:
   build:
@@ -61,4 +62,8 @@ jobs:
     # Test
       - run:
           name: Test
+<<<<<<< HEAD
           command: 'cd build && tests/engineTests'
+=======
+          command: 'cd build && tests/engineTests'
+>>>>>>> (bitboards) Add tests for implemented functions, use catch instead of ctest as it seems cleaner for now.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,4 @@ jobs:
     # Test
       - run:
           name: Test
-<<<<<<< HEAD
           command: 'cd build && tests/engineTests'
-=======
-          command: 'cd build && tests/engineTests'
->>>>>>> f6eb477e140cf30a52c26d2f27987ebdbb974c8d

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# TODO: Add nightly builds to test windows/clang for arch specific functions
-# TODO: Add store_test_results step
+# TODO: Add architecture specific nightly tests
 
 jobs:
   build:
@@ -62,8 +61,4 @@ jobs:
     # Test
       - run:
           name: Test
-<<<<<<< HEAD
           command: 'cd build && tests/engineTests'
-=======
-          command: 'cd build && tests/engineTests'
->>>>>>> (bitboards) Add tests for implemented functions, use catch instead of ctest as it seems cleaner for now.

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -1,1 +1,22 @@
 #include "bitboard.h"
+
+#include <sstream>
+
+namespace shepichess {
+
+    void bitboards::init() {
+        // TODO: Implement magic bitboards.
+    }
+
+    std::string bitboards::repr(Bitboard board) {
+        std::ostringstream ss;
+        for(int i = 7; i >= 0; i--) {
+            for(int j = 7; j >= 0; j--) {
+                ss << getbit(board, i*8 + j) << " ";
+            }
+            ss << "\n";
+        }
+        return ss.str();
+    }
+
+} // namespace shepichess

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -1,0 +1,1 @@
+#include "bitboard.h"

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -4,19 +4,19 @@
 
 namespace shepichess {
 
-    void bitboards::init() {
-        // TODO: Implement magic bitboards.
-    }
+void bitboards::init() {
+  // TODO: Implement magic bitboards.
+}
 
-    std::string bitboards::repr(Bitboard board) {
-        std::ostringstream ss;
-        for(int i = 7; i >= 0; i--) {
-            for(int j = 7; j >= 0; j--) {
-                ss << getbit(board, i*8 + j) << " ";
-            }
-            ss << "\n";
-        }
-        return ss.str();
+std::string bitboards::repr(Bitboard board) {
+  std::ostringstream out;
+  for(int i = 7; i >= 0; i--) {
+    for(int j = 7; j >= 0; j--) {
+      out << bitboards::getbit(board, i*8 + j) << " ";
     }
+    out << "\n";
+  }
+  return out.str();
+}
 
 } // namespace shepichess

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -42,7 +42,7 @@ namespace bitboards {
 void init();
 std::string repr(Bitboard);
 
-constexpr Bitboard square(unsigned int);
+constexpr Bitboard fromSquare(unsigned int);
 constexpr bool getbit(Bitboard, unsigned int);
 constexpr Bitboard setbit(Bitboard, unsigned int);
 constexpr Bitboard clearbit(Bitboard, unsigned int);
@@ -56,24 +56,24 @@ template<Direction> constexpr Bitboard shift(Bitboard);
 
 // Implementations for template and inline functions
 
-constexpr Bitboard bitboards::square(unsigned int idx)
+constexpr Bitboard bitboards::fromSquare(unsigned int idx)
 {
   return 1ULL << idx;
 }
 
 constexpr bool bitboards::getbit(Bitboard board, unsigned int idx)
 {
-  return square(idx) & board; 
+  return fromSquare(idx) & board; 
 }
 
 constexpr Bitboard bitboards::setbit(Bitboard board, unsigned int idx)
 {
-  return square(idx) | board;
+  return fromSquare(idx) | board;
 }
 
 constexpr Bitboard bitboards::clearbit(Bitboard board, unsigned int idx) 
 {
-  return ~square(idx) & board;
+  return ~fromSquare(idx) & board;
 }
 
 constexpr Bitboard bitboards::poplsb(Bitboard board) 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// Includes for popcount and other bit ops
+#if __cplusplus >= 202002L
+    #include <bits>
+#elif defined(_WIN32)
+    #include <intrin.h>
+#endif
+
+namespace shepichess {
+    
+    using Bitboard = uint64_t;
+    enum class Direction {
+        North,
+        East,
+        South,
+        West,
+        NorthEast,
+        SouthEast,
+        SouthWest,
+        NorthWest
+    };
+
+    namespace bitboards {
+
+        void init();
+        std::string repr(Bitboard);
+        constexpr bool getbit(Bitboard, unsigned int);
+        constexpr Bitboard setbit(Bitboard, unsigned int);
+        constexpr Bitboard clearbit(Bitboard, unsigned int);
+        constexpr Bitboard poplsb(Bitboard);
+        constexpr int bitscan(Bitboard);
+        constexpr unsigned int popcount(Bitboard);
+        template<Direction> constexpr Bitboard shift(Bitboard);
+
+        constexpr inline Bitboard ranks[8] = {
+            0xffULL << 0,  0xffULL << 8,  0xffULL << 16, 0xffULL << 24,
+            0xffULL << 32, 0xffULL << 40, 0xffULL << 48, 0xffULL << 56
+        };       
+        #define AFILE 0x8080'8080'8080'8080ULL
+        constexpr inline Bitboard files[8] = {
+            AFILE >> 0, AFILE >> 2, AFILE >> 3, AFILE >> 4,
+            AFILE >> 5, AFILE >> 6, AFILE >> 7, AFILE >> 8
+        };
+        #undef AFILE
+
+    } // namespace bitboards
+
+
+    constexpr bool bitboards::getbit(Bitboard board, unsigned int idx)
+    {
+        return (1ULL << idx) & board; 
+    }
+
+    constexpr Bitboard bitboards::setbit(Bitboard board, unsigned int idx)
+    {
+        return (1ULL << idx) | board;
+    }
+
+    constexpr Bitboard bitboards::clearbit(Bitboard board, unsigned int idx) 
+    {
+        return ~(1ULL << idx) & board;
+    }
+
+    constexpr Bitboard bitboards::poplsb(Bitboard board) 
+    {
+        return board & (board - 1);
+    }
+
+    constexpr int bitboards::bitscan(Bitboard board) 
+    {
+        #if defined(__clang__) || defined(__GNUC__)
+            return __builtin_ffsll(board) - 1;
+
+        #elif defined(_WIN32)
+            unsigned long idx;
+            _BitScanForward64(&idx, board);
+            return idx;
+
+        #else   
+            // Todo: Use DeBruijin bitscan to support more compilers
+            #error "Forward BitScan not implemented, use a supported compiler"
+        #endif
+    }
+
+    constexpr unsigned int bitboards::popcount(Bitboard board)
+    {
+        #if __cplusplus > 202002L
+            return std::popcount(board);
+
+        #elif defined(__clang__) || defined(__GNUC__)
+            return __builtin_popcountll(board);
+
+        #elif defined(_WIN32)
+            return __popcount64(board);
+
+        #elif defined(__INTEL_COMPILER)
+            return static_cast<int>(_mm_popcnt_u64(board));
+
+        #else
+            // Perform Bit Hackery - TODO: Explain this in documentation somewhere
+            const int mask2 = 0x3333'3333'3333'3333ULL;
+            board = board - ((board >> 1) & 0x5555'5555'5555'5555ULL;
+            board = (board & mask2) + ((board >> 2) & mask2);
+            board = board + ((board >> 4) & 0x0f0f'0f0f'0f0f'0f0fULL)
+            return static_cast<unsigned int>((board * 0x0101'0101'0101'0101ULL) >> 56);
+        #endif
+    }
+
+} // namespace shepichess

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -4,149 +4,149 @@
 #include <string>
 
 #if __cplusplus >= 202002L
-    #include <bits>
+#include <bits>
 #elif defined(_WIN32)
-    #include <intrin.h>
+#include <intrin.h>
 #endif
 
 namespace shepichess {
     
-    using Bitboard = std::uint64_t;
+using Bitboard = std::uint64_t;
 
-    enum class Direction {
-        North,
-        East,
-        South,
-        West,
-        NorthEast,
-        SouthEast,
-        SouthWest,
-        NorthWest
-    };
-    
-    // File bitboards
-    constexpr Bitboard kFileA = 0x8080'8080'8080'8080ULL;
-    constexpr Bitboard kFileB = kFileA >> 1;
-    constexpr Bitboard kFileG = kFileA >> 6;
-    constexpr Bitboard kFileH = kFileA >> 7;
-    constexpr Bitboard kFileAB = kFileA | kFileB;
-    constexpr Bitboard kFileGH = kFileG | kFileH;
-    // Rank bitboards
-    constexpr Bitboard kRank1 = 0xffULL;
-    constexpr Bitboard kRank2 = kRank1 << 8;
-    constexpr Bitboard kRank7 = kRank1 << 48;
-    constexpr Bitboard kRank8 = kRank1 << 56;
+enum class Direction {
+  North,
+  East,
+  South,
+  West,
+  NorthEast,
+  SouthEast,
+  SouthWest,
+  NorthWest
+};
 
-    namespace bitboards {
+// File bitboards
+constexpr Bitboard kFileA = 0x8080'8080'8080'8080ULL;
+constexpr Bitboard kFileB = kFileA >> 1;
+constexpr Bitboard kFileG = kFileA >> 6;
+constexpr Bitboard kFileH = kFileA >> 7;
+constexpr Bitboard kFileAB = kFileA | kFileB;
+constexpr Bitboard kFileGH = kFileG | kFileH;
+// Rank bitboards
+constexpr Bitboard kRank1 = 0xffULL;
+constexpr Bitboard kRank2 = kRank1 << 8;
+constexpr Bitboard kRank7 = kRank1 << 48;
+constexpr Bitboard kRank8 = kRank1 << 56;
 
-        void init();
-        std::string repr(Bitboard);
+namespace bitboards {
 
-        constexpr Bitboard square(unsigned int);
-        constexpr bool getbit(Bitboard, unsigned int);
-        constexpr Bitboard setbit(Bitboard, unsigned int);
-        constexpr Bitboard clearbit(Bitboard, unsigned int);
-        constexpr Bitboard poplsb(Bitboard);
-        constexpr int bitscan(Bitboard);
-        constexpr unsigned int popcount(Bitboard);
-        template<Direction> constexpr Bitboard shift(Bitboard);
+void init();
+std::string repr(Bitboard);
 
-    } // namespace shepichess::bitboards
+constexpr Bitboard square(unsigned int);
+constexpr bool getbit(Bitboard, unsigned int);
+constexpr Bitboard setbit(Bitboard, unsigned int);
+constexpr Bitboard clearbit(Bitboard, unsigned int);
+constexpr Bitboard poplsb(Bitboard);
+constexpr int bitscan(Bitboard);
+constexpr unsigned int popcount(Bitboard);
+template<Direction> constexpr Bitboard shift(Bitboard);
+
+} // namespace shepichess::bitboards
 
 
-    // Implementations for template and inline functions
+// Implementations for template and inline functions
 
-    constexpr Bitboard bitboards::square(unsigned int idx)
-    {
-        return 1ULL << idx;
-    }
+constexpr Bitboard bitboards::square(unsigned int idx)
+{
+  return 1ULL << idx;
+}
 
-    constexpr bool bitboards::getbit(Bitboard board, unsigned int idx)
-    {
-        return square(idx) & board; 
-    }
+constexpr bool bitboards::getbit(Bitboard board, unsigned int idx)
+{
+  return square(idx) & board; 
+}
 
-    constexpr Bitboard bitboards::setbit(Bitboard board, unsigned int idx)
-    {
-        return square(idx) | board;
-    }
+constexpr Bitboard bitboards::setbit(Bitboard board, unsigned int idx)
+{
+  return square(idx) | board;
+}
 
-    constexpr Bitboard bitboards::clearbit(Bitboard board, unsigned int idx) 
-    {
-        return ~square(idx) & board;
-    }
+constexpr Bitboard bitboards::clearbit(Bitboard board, unsigned int idx) 
+{
+  return ~square(idx) & board;
+}
 
-    constexpr Bitboard bitboards::poplsb(Bitboard board) 
-    {
-        return board & (board - 1);
-    }
+constexpr Bitboard bitboards::poplsb(Bitboard board) 
+{
+  return board & (board - 1);
+}
 
-    constexpr int bitboards::bitscan(Bitboard board) 
-    {
-        #if defined(__clang__) || defined(__GNUC__)
-            return __builtin_ffsll(board) - 1;
+constexpr int bitboards::bitscan(Bitboard board) 
+{
+#if defined(__clang__) || defined(__GNUC__)
+  return __builtin_ffsll(board) - 1;
 
-        #elif defined(_WIN64)
-            #pragma intrinsic(_BitScanForward64)
-            unsigned long idx;
-            if(_BitScanForward64(&idx, board)) {
-                return idx;
-            }
-            return -1;
-        
-        #elif defined(_WIN32)
-            #pragma intrinsic(_BitScanForward)
-            unsigned long lower, upper;
-            if(_BitScanForward(&lower, static_cast<unsigned long>(board))) {
-                return lower;
-            }
-            return _BitScanForward(&upper, static_cast<unsigned long>(board >> 32)) ? upper : -1;
+#elif defined(_WIN64)
+  #pragma intrinsic(_BitScanForward64)
+  unsigned long idx;
+  if(_BitScanForward64(&idx, board)) {
+    return idx;
+  }
+  return -1;
 
-        #else   
-            // Todo: Use DeBruijin bitscan to support more compilers
-            #error "Forward BitScan not implemented, use a supported compiler"
-        #endif
-    }
+#elif defined(_WIN32)
+#pragma intrinsic(_BitScanForward)
+  unsigned long lower, upper;
+  if(_BitScanForward(&lower, static_cast<unsigned long>(board))) {
+    return lower;
+  }
+  return _BitScanForward(&upper, static_cast<unsigned long>(board >> 32)) ? upper : -1;
 
-    constexpr unsigned int bitboards::popcount(Bitboard board)
-    {
-        #if __cplusplus > 202002L
-            return std::popcount(board);
+#else   
+// Todo: Use DeBruijin bitscan to support more compilers
+#error "Forward BitScan not implemented, use a supported compiler"
+#endif
+}
 
-        #elif defined(__clang__) || defined(__GNUC__)
-            return __builtin_popcountll(board);
+constexpr unsigned int bitboards::popcount(Bitboard board)
+{
+#if __cplusplus > 202002L
+  return std::popcount(board);
 
-        #elif defined(_WIN64)
-            return __popcount64(board);
+#elif defined(__clang__) || defined(__GNUC__)
+  return __builtin_popcountll(board);
 
-        #elif defined(_WIN32)
-            return __popcount(static_cast<unsigned long>(board) + 
-                   __popcount(static_cast<unsigned long>(board >> 32));
+#elif defined(_WIN64)
+  return __popcount64(board);
 
-        #elif defined(__INTEL_COMPILER)
-            return static_cast<int>(_mm_popcnt_u64(board));
+#elif defined(_WIN32)
+  return __popcount(static_cast<unsigned long>(board) + 
+         __popcount(static_cast<unsigned long>(board >> 32));
 
-        #else
-            // Perform Bit Hackery - TODO: Explain this in documentation somewhere
-            const int mask2 = 0x3333'3333'3333'3333ULL;
-            board = board - ((board >> 1) & 0x5555'5555'5555'5555ULL;
-            board = (board & mask2) + ((board >> 2) & mask2);
-            board = board + ((board >> 4) & 0x0f0f'0f0f'0f0f'0f0fULL)
-            return static_cast<unsigned int>((board * 0x0101'0101'0101'0101ULL) >> 56);
-        #endif
-    }
+#elif defined(__INTEL_COMPILER)
+  return static_cast<int>(_mm_popcnt_u64(board));
 
-    template<Direction dir>
-    constexpr Bitboard bitboards::shift(Bitboard board) 
-    {
-        if constexpr(dir == Direction::North) return (board << 8); 
-        if constexpr(dir == Direction::South) return (board >> 8);
-        if constexpr(dir == Direction::East) return (board >> 1) & ~kFileA;
-        if constexpr(dir == Direction::West) return (board << 1) & ~kFileH;
-        if constexpr(dir == Direction::NorthEast) return (board << 7) & ~kFileA;
-        if constexpr(dir == Direction::SouthEast) return (board >> 9) & ~kFileA;
-        if constexpr(dir == Direction::NorthWest) return (board << 9) & ~kFileH;
-        if constexpr(dir == Direction::SouthWest) return (board >> 7) & ~kFileH;
-    }
+#else
+  // Perform Bit Hackery - TODO: Explain this in documentation somewhere
+  const int mask2 = 0x3333'3333'3333'3333ULL;
+  board = board - ((board >> 1) & 0x5555'5555'5555'5555ULL;
+  board = (board & mask2) + ((board >> 2) & mask2);
+  board = board + ((board >> 4) & 0x0f0f'0f0f'0f0f'0f0fULL)
+  return static_cast<unsigned int>((board * 0x0101'0101'0101'0101ULL) >> 56);
+#endif
+}
+
+template<Direction dir>
+constexpr Bitboard bitboards::shift(Bitboard board) 
+{
+  if constexpr(dir == Direction::North) return (board << 8); 
+  if constexpr(dir == Direction::South) return (board >> 8);
+  if constexpr(dir == Direction::East) return (board >> 1) & ~kFileA;
+  if constexpr(dir == Direction::West) return (board << 1) & ~kFileH;
+  if constexpr(dir == Direction::NorthEast) return (board << 7) & ~kFileA;
+  if constexpr(dir == Direction::SouthEast) return (board >> 9) & ~kFileA;
+  if constexpr(dir == Direction::NorthWest) return (board << 9) & ~kFileH;
+  if constexpr(dir == Direction::SouthWest) return (board >> 7) & ~kFileH;
+}
 
 } // namespace shepichess

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
 
 int main() {
-    std::cout << "Hello World!\n";
+  std::cout << "Hello World!\n";
 }

--- a/tests/testbitboard.cpp
+++ b/tests/testbitboard.cpp
@@ -1,7 +1,51 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "bitboard.h"
+using namespace shepichess::bitboards;
 
-TEST_CASE("First test!", "[bitboard]") {
-    REQUIRE(1 == 1);
+TEST_CASE("bitboards::getbit", "[bitboard]") {
+    REQUIRE(getbit(10, 0) == 0);
+    REQUIRE(getbit(10, 1) == 1);
+    REQUIRE(getbit(10, 2) == 0);
+    REQUIRE(getbit(10, 3) == 1);
+    REQUIRE(getbit(0x8000'0000'0000'0000ULL, 63) == 1);
+    REQUIRE(getbit(0x7000'0000'0000'0000ULL, 63) == 0);
+}
+
+TEST_CASE("bitboards::setbit", "[bitboard]") {
+    REQUIRE(setbit(10, 2) == 14);
+    REQUIRE(setbit(20, 3) == 28);
+    REQUIRE(setbit(30, 3) == 30);
+    REQUIRE(setbit(50, 0) == 51);
+    REQUIRE(setbit(0, 63) == 0x8000'0000'0000'0000ULL);
+}
+
+TEST_CASE("bitboards::clearbit", "[bitboard]") {
+    REQUIRE(clearbit(10, 1) == 8);
+    REQUIRE(clearbit(20, 4) == 4);
+    REQUIRE(clearbit(30, 3) == 22);
+    REQUIRE(clearbit(0xf000'0000'0000'0000ULL, 63) == 0x7000'0000'0000'0000ULL);
+}
+
+TEST_CASE("bitboards::poplsb", "[bitboard]") {
+    REQUIRE(poplsb(10) == 8);
+    REQUIRE(poplsb(20) == 16);
+    REQUIRE(poplsb(40) == 32);
+    REQUIRE(poplsb(0x8000'0000'0000'0000ULL) == 0);
+}
+
+TEST_CASE("bitboards::bitscan", "[bitboard]") {
+    REQUIRE(bitscan(10) == 1);
+    REQUIRE(bitscan(20) == 2);
+    REQUIRE(bitscan(30) == 1);
+    REQUIRE(bitscan(40) == 3);
+    REQUIRE(bitscan(0x8000'0000'0000'0000ULL) == 63);
+}
+
+TEST_CASE("bitboards::popcount", "[bitboard]") {
+    REQUIRE(popcount(10) == 2);
+    REQUIRE(popcount(20) == 2);
+    REQUIRE(popcount(30) == 4);
+    REQUIRE(popcount(50) == 3);
+    REQUIRE(popcount(0xffff'ffff'ffff'ffffULL) == 64);
 }

--- a/tests/testbitboard.cpp
+++ b/tests/testbitboard.cpp
@@ -52,9 +52,10 @@ TEST_CASE("bitboards::popcount", "[bitboard]") {
   REQUIRE(popcount(0xffff'ffff'ffff'ffffULL) == 64);
 }
 
-// Test that shifting a square in the center works as expected
+// Test that shifting a fromSquare in the center works as expected
 TEST_CASE("bitboards::shift center", "[bitboard]") {
-  Bitboard e4 = square(27), d4 = square(28), e5 = square(35), d5 = square(36);
+  Bitboard e4 = fromSquare(27), d4 = fromSquare(28);
+  Bitboard e5 = fromSquare(35), d5 = fromSquare(36);
   REQUIRE(shift<Direction::East>(d4) == e4);
   REQUIRE(shift<Direction::West>(e4) == d4);
   REQUIRE(shift<Direction::North>(e4) == e5);
@@ -68,7 +69,8 @@ TEST_CASE("bitboards::shift center", "[bitboard]") {
 
 // Test that shifting doesn't wrap around across edges
 TEST_CASE("bitboards::shift edge", "[bitboard]") {
-  Bitboard a4 = square(31), h4 = square(24), e1 = square(3), e8=square(59);
+  Bitboard a4 = fromSquare(31), h4 = fromSquare(24);
+  Bitboard e1 = fromSquare(3), e8 = fromSquare(59);
   // East
   REQUIRE(shift<Direction::NorthEast>(h4) == 0);
   REQUIRE(shift<Direction::East>(h4) == 0);

--- a/tests/testbitboard.cpp
+++ b/tests/testbitboard.cpp
@@ -6,83 +6,83 @@ using shepichess::Bitboard, shepichess::Direction;
 using namespace shepichess::bitboards;
 
 TEST_CASE("bitboards::getbit", "[bitboard]") {
-    REQUIRE(getbit(10, 0) == 0);
-    REQUIRE(getbit(10, 1) == 1);
-    REQUIRE(getbit(10, 2) == 0);
-    REQUIRE(getbit(10, 3) == 1);
-    REQUIRE(getbit(0x8000'0000'0000'0000ULL, 63) == 1);
-    REQUIRE(getbit(0x7000'0000'0000'0000ULL, 63) == 0);
+  REQUIRE(getbit(10, 0) == 0);
+  REQUIRE(getbit(10, 1) == 1);
+  REQUIRE(getbit(10, 2) == 0);
+  REQUIRE(getbit(10, 3) == 1);
+  REQUIRE(getbit(0x8000'0000'0000'0000ULL, 63) == 1);
+  REQUIRE(getbit(0x7000'0000'0000'0000ULL, 63) == 0);
 }
 
 TEST_CASE("bitboards::setbit", "[bitboard]") {
-    REQUIRE(setbit(10, 2) == 14);
-    REQUIRE(setbit(20, 3) == 28);
-    REQUIRE(setbit(30, 3) == 30);
-    REQUIRE(setbit(50, 0) == 51);
-    REQUIRE(setbit(0, 63) == 0x8000'0000'0000'0000ULL);
+  REQUIRE(setbit(10, 2) == 14);
+  REQUIRE(setbit(20, 3) == 28);
+  REQUIRE(setbit(30, 3) == 30);
+  REQUIRE(setbit(50, 0) == 51);
+  REQUIRE(setbit(0, 63) == 0x8000'0000'0000'0000ULL);
 }
 
 TEST_CASE("bitboards::clearbit", "[bitboard]") {
-    REQUIRE(clearbit(10, 1) == 8);
-    REQUIRE(clearbit(20, 4) == 4);
-    REQUIRE(clearbit(30, 3) == 22);
-    REQUIRE(clearbit(0xf000'0000'0000'0000ULL, 63) == 0x7000'0000'0000'0000ULL);
+  REQUIRE(clearbit(10, 1) == 8);
+  REQUIRE(clearbit(20, 4) == 4);
+  REQUIRE(clearbit(30, 3) == 22);
+  REQUIRE(clearbit(0xf000'0000'0000'0000ULL, 63) == 0x7000'0000'0000'0000ULL);
 }
 
 TEST_CASE("bitboards::poplsb", "[bitboard]") {
-    REQUIRE(poplsb(10) == 8);
-    REQUIRE(poplsb(20) == 16);
-    REQUIRE(poplsb(40) == 32);
-    REQUIRE(poplsb(0x8000'0000'0000'0000ULL) == 0);
+  REQUIRE(poplsb(10) == 8);
+  REQUIRE(poplsb(20) == 16);
+  REQUIRE(poplsb(40) == 32);
+  REQUIRE(poplsb(0x8000'0000'0000'0000ULL) == 0);
 }
 
 TEST_CASE("bitboards::bitscan", "[bitboard]") {
-    REQUIRE(bitscan(10) == 1);
-    REQUIRE(bitscan(20) == 2);
-    REQUIRE(bitscan(30) == 1);
-    REQUIRE(bitscan(40) == 3);
-    REQUIRE(bitscan(0x8000'0000'0000'0000ULL) == 63);
+  REQUIRE(bitscan(10) == 1);
+  REQUIRE(bitscan(20) == 2);
+  REQUIRE(bitscan(30) == 1);
+  REQUIRE(bitscan(40) == 3);
+  REQUIRE(bitscan(0x8000'0000'0000'0000ULL) == 63);
 }
 
 TEST_CASE("bitboards::popcount", "[bitboard]") {
-    REQUIRE(popcount(10) == 2);
-    REQUIRE(popcount(20) == 2);
-    REQUIRE(popcount(30) == 4);
-    REQUIRE(popcount(50) == 3);
-    REQUIRE(popcount(0xffff'ffff'ffff'ffffULL) == 64);
+  REQUIRE(popcount(10) == 2);
+  REQUIRE(popcount(20) == 2);
+  REQUIRE(popcount(30) == 4);
+  REQUIRE(popcount(50) == 3);
+  REQUIRE(popcount(0xffff'ffff'ffff'ffffULL) == 64);
 }
 
 // Test that shifting a square in the center works as expected
 TEST_CASE("bitboards::shift center", "[bitboard]") {
-    Bitboard e4 = square(27), d4 = square(28), e5 = square(35), d5 = square(36);
-    REQUIRE(shift<Direction::East>(d4) == e4);
-    REQUIRE(shift<Direction::West>(e4) == d4);
-    REQUIRE(shift<Direction::North>(e4) == e5);
-    REQUIRE(shift<Direction::South>(e5) == e4);
+  Bitboard e4 = square(27), d4 = square(28), e5 = square(35), d5 = square(36);
+  REQUIRE(shift<Direction::East>(d4) == e4);
+  REQUIRE(shift<Direction::West>(e4) == d4);
+  REQUIRE(shift<Direction::North>(e4) == e5);
+  REQUIRE(shift<Direction::South>(e5) == e4);
 
-    REQUIRE(shift<Direction::NorthEast>(d4) == e5);
-    REQUIRE(shift<Direction::SouthEast>(d5) == e4);
-    REQUIRE(shift<Direction::NorthWest>(e4) == d5);
-    REQUIRE(shift<Direction::SouthWest>(e5) == d4);
+  REQUIRE(shift<Direction::NorthEast>(d4) == e5);
+  REQUIRE(shift<Direction::SouthEast>(d5) == e4);
+  REQUIRE(shift<Direction::NorthWest>(e4) == d5);
+  REQUIRE(shift<Direction::SouthWest>(e5) == d4);
 }
 
 // Test that shifting doesn't wrap around across edges
 TEST_CASE("bitboards::shift edge", "[bitboard]") {
-    Bitboard a4 = square(31), h4 = square(24), e1 = square(3), e8=square(59);
-    // East
-    REQUIRE(shift<Direction::NorthEast>(h4) == 0);
-    REQUIRE(shift<Direction::East>(h4) == 0);
-    REQUIRE(shift<Direction::SouthEast>(h4) == 0);
-    // West
-    REQUIRE(shift<Direction::NorthWest>(a4) == 0);
-    REQUIRE(shift<Direction::West>(a4) == 0);
-    REQUIRE(shift<Direction::SouthWest>(a4) == 0);
-    // North
-    REQUIRE(shift<Direction::NorthWest>(e8) == 0);
-    REQUIRE(shift<Direction::North>(e8) == 0);
-    REQUIRE(shift<Direction::NorthEast>(e8) == 0);
-    // South
-    REQUIRE(shift<Direction::SouthWest>(e1) == 0);
-    REQUIRE(shift<Direction::South>(e1) == 0);
-    REQUIRE(shift<Direction::SouthEast>(e1) == 0);
+  Bitboard a4 = square(31), h4 = square(24), e1 = square(3), e8=square(59);
+  // East
+  REQUIRE(shift<Direction::NorthEast>(h4) == 0);
+  REQUIRE(shift<Direction::East>(h4) == 0);
+  REQUIRE(shift<Direction::SouthEast>(h4) == 0);
+  // West
+  REQUIRE(shift<Direction::NorthWest>(a4) == 0);
+  REQUIRE(shift<Direction::West>(a4) == 0);
+  REQUIRE(shift<Direction::SouthWest>(a4) == 0);
+  // North
+  REQUIRE(shift<Direction::NorthWest>(e8) == 0);
+  REQUIRE(shift<Direction::North>(e8) == 0);
+  REQUIRE(shift<Direction::NorthEast>(e8) == 0);
+  // South
+  REQUIRE(shift<Direction::SouthWest>(e1) == 0);
+  REQUIRE(shift<Direction::South>(e1) == 0);
+  REQUIRE(shift<Direction::SouthEast>(e1) == 0);
 }

--- a/tests/testbitboard.cpp
+++ b/tests/testbitboard.cpp
@@ -1,6 +1,8 @@
+#include "bitboard.h"
+
 #include <catch2/catch_test_macros.hpp>
 
-#include "bitboard.h"
+using shepichess::Bitboard, shepichess::Direction;
 using namespace shepichess::bitboards;
 
 TEST_CASE("bitboards::getbit", "[bitboard]") {
@@ -48,4 +50,39 @@ TEST_CASE("bitboards::popcount", "[bitboard]") {
     REQUIRE(popcount(30) == 4);
     REQUIRE(popcount(50) == 3);
     REQUIRE(popcount(0xffff'ffff'ffff'ffffULL) == 64);
+}
+
+// Test that shifting a square in the center works as expected
+TEST_CASE("bitboards::shift center", "[bitboard]") {
+    Bitboard e4 = square(27), d4 = square(28), e5 = square(35), d5 = square(36);
+    REQUIRE(shift<Direction::East>(d4) == e4);
+    REQUIRE(shift<Direction::West>(e4) == d4);
+    REQUIRE(shift<Direction::North>(e4) == e5);
+    REQUIRE(shift<Direction::South>(e5) == e4);
+
+    REQUIRE(shift<Direction::NorthEast>(d4) == e5);
+    REQUIRE(shift<Direction::SouthEast>(d5) == e4);
+    REQUIRE(shift<Direction::NorthWest>(e4) == d5);
+    REQUIRE(shift<Direction::SouthWest>(e5) == d4);
+}
+
+// Test that shifting doesn't wrap around across edges
+TEST_CASE("bitboards::shift edge", "[bitboard]") {
+    Bitboard a4 = square(31), h4 = square(24), e1 = square(3), e8=square(59);
+    // East
+    REQUIRE(shift<Direction::NorthEast>(h4) == 0);
+    REQUIRE(shift<Direction::East>(h4) == 0);
+    REQUIRE(shift<Direction::SouthEast>(h4) == 0);
+    // West
+    REQUIRE(shift<Direction::NorthWest>(a4) == 0);
+    REQUIRE(shift<Direction::West>(a4) == 0);
+    REQUIRE(shift<Direction::SouthWest>(a4) == 0);
+    // North
+    REQUIRE(shift<Direction::NorthWest>(e8) == 0);
+    REQUIRE(shift<Direction::North>(e8) == 0);
+    REQUIRE(shift<Direction::NorthEast>(e8) == 0);
+    // South
+    REQUIRE(shift<Direction::SouthWest>(e1) == 0);
+    REQUIRE(shift<Direction::South>(e1) == 0);
+    REQUIRE(shift<Direction::SouthEast>(e1) == 0);
 }


### PR DESCRIPTION
Added basic functionality such as setting/clearing bits, along with architecture specific code for intrinsic functions (popcount/bitscan). There also is a templated shift function that handles named directions and prevents any wraparound.

Also added support for printing bitboards for possible use in logging later.

Code has been tested on GCC only so far.