### PR TITLE
Fix windows cmake dependency issues.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,9 +12,9 @@ add_dependencies(engineTests engine)
 target_link_libraries(engineTests PRIVATE engine)
 
 add_dependencies(engineTests Catch2)
-target_include_directories(engine PUBLIC ${PROJECT_SOURCE_DIR}/bin/Catch2/include)
-target_link_libraries(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Catch2Main${CMAKE_STATIC_LIBRARY_SUFFIX})
-target_link_libraries(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Catch2${CMAKE_STATIC_LIBRARY_SUFFIX})
+target_include_directories(engineTests PUBLIC ${PROJECT_SOURCE_DIR}/bin/Catch2/include)
+target_link_libraries(engineTests PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Catch2Main${CMAKE_STATIC_LIBRARY_SUFFIX})
+target_link_libraries(engineTests PRIVATE ${PROJECT_SOURCE_DIR}/bin/Catch2/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Catch2${CMAKE_STATIC_LIBRARY_SUFFIX})
 
 include(Catch)
 catch_discover_tests(engineTests)


### PR DESCRIPTION
We were linking catch2 against the engine library, even though it is only used in the tests. This caused linking to possibly fail, as only the tests had a dependency on catch2 being available.