### PR TITLE
Add windows and nightly builds to circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,17 @@
 version: 2.1
 
 # TODO: Add nightly builds to test windows/clang for arch specific functions
-# TODO: Add store_test_results step
+
+orbs:
+  circleci/windows@2.4.0
 
 jobs:
-  build:
+  linux-gcc:
     docker:
       - image: cimg/base:2021.04
-
+      - environment:
+        CC: gcc-9
+        CXX: g++-9
     steps:
     # Initial Git checkout with submodules
       - checkout
@@ -65,3 +69,31 @@ jobs:
           command: 'cd build && mkdir testresults && tests/engineTests -r junit >testresults/testEngine.xml'
       - store_test_results:
           path: 'build/testresults'
+
+
+  windows:
+    executor: win/default
+    steps:
+      - checkout
+      - run:
+        name: Install git submodules
+        command: git submodule update --init --recursive
+      - run:
+        name: Install CMAKE
+        command: choco install cmake -y 
+      - run:
+        name: Configure with Cmake
+        command: cmake -H. -Bbuild
+      - run:
+        name: Build
+        command: cd build && make -j16
+      - run:
+        name: Test
+        command: 'cd build && tests/engineTests'
+
+workflows:
+  version: 2
+  run-all:
+    jobs:
+      - linux-gcc
+      - windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ jobs:
       - store_test_results:
           path: 'build/testresults'
 
-
   windows:
     executor: win/default
     steps:
@@ -89,7 +88,9 @@ jobs:
           command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cd build; cmake --build .
       - run:
           name: Test
-          command: 'cd build; tests\Debug\engineTests'
+          command: 'cd build; mkdir testresults; tests\Debug\engineTests -r junit >testresults\testEngine.xml'
+      - store_test_results:
+          path: 'build\testresults'
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           command: git submodule update --init --recursive
       - run:
           name: Install CMAKE
-          command: choco install cmake -y 
+          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\CMake\bin";
       - run:
           name: Configure with Cmake
           command: cmake -H. -Bbuild
@@ -91,9 +91,20 @@ jobs:
           name: Test
           command: 'cd build && tests/engineTests'
 
+
 workflows:
   version: 2
-  run-all:
+  commit:
     jobs:
       - linux-gcc
       - windows
+  nightly:
+    jobs:
+      - linux-gcc
+      - windows
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           command: git submodule update --init --recursive
       - run:
           name: Install CMAKE
-          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\\CMake\\bin"
+          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\CMake\bin"; ls "$Env:ProgramFiles\CMake\bin" 
       - run:
           name: Configure with Cmake
           command: cmake -H. -Bbuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,7 @@ jobs:
           command: choco install cmake -y;
       - run:
           name: Configure with Cmake
-          command: >
-            $Env:Path+=";$Env:ProgramFiles\CMake\bin"
-            cmake -H. -Bbuild
+          command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cmake -H. -Bbuild
       - run:
           name: Build
           command: cd build && make -j16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,10 +80,12 @@ jobs:
           command: git submodule update --init --recursive
       - run:
           name: Install CMAKE
-          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\CMake\bin"; $Env:Path
+          command: choco install cmake -y;
       - run:
           name: Configure with Cmake
-          command: $Env:Path; cmake -H. -Bbuild
+          command: >
+            $Env:Path+=";$Env:ProgramFiles\CMake\bin"
+            cmake -H. -Bbuild
       - run:
           name: Build
           command: cd build && make -j16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     # Build
       - run:
           name: Configure with CMAKE
-          command: 'cmake -H. -Bbuild'
+          command: 'cmake . -Bbuild'
       - run:
           name: Build
           command: 'cd build && make -j$(nproc)'
@@ -83,7 +83,7 @@ jobs:
           command: choco install cmake -y;
       - run:
           name: Configure with Cmake
-          command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cmake -H. -Bbuild
+          command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cmake . -Bbuild
       - run:
           name: Build
           command: cd build && make -j16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ jobs:
   linux-gcc:
     docker:
       - image: cimg/base:2021.04
-      - environment:
-        CC: gcc-9
-        CXX: g++-9
+    environment:
+      CC: gcc-9
+      CXX: g++-9
     steps:
     # Initial Git checkout with submodules
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,14 @@ jobs:
           command: >-
             echo $(git ls-tree HEAD third_party/spdlog | awk {'print $3'}) >.spdlog_hash
       - restore_cache:
-          key: spdlogcache-v2-{{ checksum ".spdlog_hash" }}
+          key: spdlogcache-v3-{{ checksum ".spdlog_hash" }}
       # Catch2
       - run:
           name: Catch2 checksum
           command: >-
             echo $(git ls-tree HEAD third_party/Catch2 | awk {'print $3'}) >.catch2_hash
       - restore_cache:
-          key: catch2cache-v3-{{ checksum ".catch2_hash" }} 
+          key: catch2cache-v4-{{ checksum ".catch2_hash" }} 
         
     # Install required tools
       - run:
@@ -52,13 +52,13 @@ jobs:
     # Save Cache
       # spdlog
       - save_cache:
-          key: spdlogcache-v2-{{ checksum ".spdlog_hash" }}
+          key: spdlogcache-v3-{{ checksum ".spdlog_hash" }}
           paths: 
             - bin/spdlog
             - build/spdlog
       # Catch2
       - save_cache:
-          key: catch2cache-v3-{{ checksum ".catch2_hash" }}
+          key: catch2cache-v4-{{ checksum ".catch2_hash" }}
           paths:
             - bin/Catch2
             - build/Catch2
@@ -80,7 +80,7 @@ jobs:
           command: git submodule update --init --recursive
       - run:
           name: Install CMAKE
-          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\CMake\bin";
+          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\\CMake\\bin"
       - run:
           name: Configure with Cmake
           command: cmake -H. -Bbuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,10 @@ jobs:
           command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cmake . -Bbuild
       - run:
           name: Build
-          command: cd build && make -j16
+          command: cd build; cmake --build .
       - run:
           name: Test
-          command: 'cd build && tests/engineTests'
+          command: 'cd build; tests\Debug\engineTests'
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 # TODO: Add nightly builds to test windows/clang for arch specific functions
 
 orbs:
-  circleci/windows@2.4.0
+  win: circleci/windows@2.4.0
 
 jobs:
   linux-gcc:
@@ -76,20 +76,20 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Install git submodules
-        command: git submodule update --init --recursive
+          name: Install git submodules
+          command: git submodule update --init --recursive
       - run:
-        name: Install CMAKE
-        command: choco install cmake -y 
+          name: Install CMAKE
+          command: choco install cmake -y 
       - run:
-        name: Configure with Cmake
-        command: cmake -H. -Bbuild
+          name: Configure with Cmake
+          command: cmake -H. -Bbuild
       - run:
-        name: Build
-        command: cd build && make -j16
+          name: Build
+          command: cd build && make -j16
       - run:
-        name: Test
-        command: 'cd build && tests/engineTests'
+          name: Test
+          command: 'cd build && tests/engineTests'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,10 @@ jobs:
           command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cd build; cmake --build .
       - run:
           name: Test
-          command: 'cd build; mkdir testresults; tests\Debug\engineTests -r junit >testresults\testEngine.xml'
+          command: >-
+            cd build; 
+            mkdir testresults; 
+            tests\Debug\engineTests -r junit | Out-File -FilePath testresults\testEngine.xml -Encoding ASCII
       - store_test_results:
           path: 'build\testresults'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# TODO: Add nightly builds to test windows/clang for arch specific functions
-
 orbs:
   win: circleci/windows@2.4.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cmake . -Bbuild
       - run:
           name: Build
-          command: cd build; cmake --build .
+          command: $Env:Path+=";$Env:ProgramFiles\CMake\bin"; cd build; cmake --build .
       - run:
           name: Test
           command: 'cd build; tests\Debug\engineTests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,10 +80,10 @@ jobs:
           command: git submodule update --init --recursive
       - run:
           name: Install CMAKE
-          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\CMake\bin"; ls "$Env:ProgramFiles\CMake\bin" 
+          command: choco install cmake -y; $Env:Path+=";$Env:ProgramFiles\CMake\bin"; $Env:Path
       - run:
           name: Configure with Cmake
-          command: cmake -H. -Bbuild
+          command: $Env:Path; cmake -H. -Bbuild
       - run:
           name: Build
           command: cd build && make -j16


### PR DESCRIPTION
Added builds for windows, which supports everything linux gcc builds do except for caching.

Also added nightly builds for the main branch.