### PR TITLE
Only build windows nightly to save circleci credits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ workflows:
   commit:
     jobs:
       - linux-gcc
-      - windows
   nightly:
     jobs:
       - linux-gcc


### PR DESCRIPTION
Windows is using at least 3x the credits that linux is, given that:
 - builds are slower
 - installing software such as cmake is slower
 - there is no caching
 - windows might also be more expensive in terms of credits used?

It will save a lot of credits to only test windows nightly, and not on every commit.