### PR TITLE
Remove windows nightly builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ workflows:
   nightly:
     jobs:
       - linux-gcc
-      - windows
     triggers:
       - schedule:
           cron: "0 0 * * *"


### PR DESCRIPTION
I spent too many circle-ci credits experimenting with these, so I'm going to disable them for this week. Will re-enable them next week when we get more free credits.