### PR TITLE
Parallel bitboard init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ commands:
       - run:
           name: "Install TBB"
           command: "sudo apt install libtbb-dev"
-  install_cl
 
   restore_third_party_cache:
     description: "Restores cache for 3rd party libraries and cmake files"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,12 @@ commands:
           command: >-
             <<# parameters.sudo >> sudo <</ parameters.sudo>> 
             << parameters.package_manager >> install cmake -y
+  install_tbb:
+    decription: "Install tbb on linux with apt-get"
+    steps:
+      - run:
+          name: "Install TBB"
+          command: "sudo apt install libtbb-dev"
 
   restore_third_party_cache:
     description: "Restores cache for 3rd party libraries and cmake files"
@@ -114,6 +120,7 @@ commands:
       - install_cmake:
           sudo: true
           package_manager: "apt-get"
+      - install_tbb
       - restore_third_party_cache
       - build
       - save_third_party_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
             <<# parameters.sudo >> sudo <</ parameters.sudo>> 
             << parameters.package_manager >> install cmake -y
   install_tbb:
-    decription: "Install tbb on linux with apt-get"
+    description: "Install tbb on linux with apt-get"
     steps:
       - run:
           name: "Install TBB"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ commands:
       - run:
           name: "Install TBB"
           command: "sudo apt install libtbb-dev"
+  install_cl
 
   restore_third_party_cache:
     description: "Restores cache for 3rd party libraries and cmake files"
@@ -156,6 +157,9 @@ jobs:
       CXX: g++-9
     steps:
       - fullbuild_linux
+      - run:
+          name: "Install clang-tidy"
+          command: "sudo apt-get update && sudo apt-get install clang-tidy" 
       - clang_tidy
   format:
     docker:

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: '
 bugprone-*,
+-bugprone-lambda-function-name,
 cppcoreguidelines-*,
 -cppcoreguidelines-avoid-magic-numbers,
 -cppcoreguidelines-macro-usage,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ target_compile_features(engine PRIVATE cxx_std_17)
 # spdlog
 add_dependencies(engine spdlog)
 target_include_directories(engine PUBLIC ${PROJECT_SOURCE_DIR}/bin/spdlog/include)
+target_link_libraries(engine PRIVATE tbb)
 if(WIN32)
 target_link_libraries(engine PRIVATE ${PROJECT_SOURCE_DIR}/bin/spdlog/lib/${CMAKE_STATIC_LIBRARY_PREFIX}spdlogd${CMAKE_STATIC_LIBRARY_SUFFIX})
 else()

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <execution>
+#include <mutex>
 #include <random>
 #include <sstream>
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_INFO
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
@@ -11,15 +13,14 @@ constexpr LogLevel kDefaultLogLevel = static_cast<LogLevel>(SPDLOG_ACTIVE_LEVEL)
 
 inline void initLogging()
 {
-  static bool initialized = false;
-  if (initialized) return;
-
-  static auto stderr_logger = spdlog::stderr_color_mt("shepichess_stderr_logger");
-  stderr_logger->set_level(kDefaultLogLevel);
-  spdlog::set_level(kDefaultLogLevel);
-  spdlog::set_default_logger(stderr_logger);
-  spdlog::set_pattern("[%Y-%m-%d %H:%M:%S] [thread %t] [%^%l%$] [%s:%#] %v");
-  initialized = true;
+  static std::once_flag init_flag;
+  std::call_once(init_flag, []() {
+    static auto stderr_logger = spdlog::stderr_color_mt("shepichess_stderr_logger");
+    stderr_logger->set_level(kDefaultLogLevel);
+    spdlog::set_level(kDefaultLogLevel);
+    spdlog::set_default_logger(stderr_logger);
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S] [thread %t] [%^%l%$] [%s:%#] %v");
+  });
 }
 
 } // namespace shepichess


### PR DESCRIPTION
Moves mt engine into a thread_local variable to make bitboard initialization functions thread safe (none of them access any shared global data at all now).

Given that they are thread (and vectorization) safe, we can use std::transform with a par_unseq execution policy to drastically speed up bitboard initialization (seems to be about 100x faster).

Also reworked initialization logic to use std::call_once, which should make it cleaner and safer (it should now also be thread safe).