### PR TITLE
Pass -j30 to cmake --build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
             <<# parameters.windows >> $Env:Path+=";$Env:ProgramFiles\CMake\bin"; <</ parameters.windows >>
             cmake . -Bbuild;
             cd build;
-            cmake --build .
+            cmake --build . -j30
   test:
     description: "Tests and stores results"
     parameters:


### PR DESCRIPTION
Increasing the number of jobs used seems to help slightly with build times.