### PR TITLE
Windows build fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ jobs:
     steps:
       - fullbuild_windows
       - test
+          windows: true
   lint:
     docker:
       - image: cimg/base:2021.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,12 @@ commands:
           command: >-
             cd build; 
             mkdir testresults; 
-            tests/engineTests -r junit           
             <<# parameters.windows >> 
-              | Out-File -FilePath testresults\testEngine.xml -Encoding ASCII 
+             tests/Debug/engineTests.exe | Out-File -FilePath testresults\testEngine.xml -Encoding ASCII 
             <</ parameters.windows >>
-            <<^ parameters.windows >> >testresults/testEngine.xml <</ parameters.windows >>
+            <<^ parameters.windows >> 
+            tests/engineTests -r junit >testresults/testEngine.xml 
+            <</ parameters.windows >>
       - store_test_results:
           path: 'build/testresults'
   # Lint / Format

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
     executor: win/default
     steps:
       - fullbuild_windows
-      - test
+      - test:
           windows: true
   lint:
     docker:


### PR DESCRIPTION
Fix windows ci script to use correct path for test command.

Test plan: untested as windows builds on commits cost too many ci credits, should run in the nightly build tonight.